### PR TITLE
Small change to run-sql-psql

### DIFF
--- a/R/run-sql-psql.R
+++ b/R/run-sql-psql.R
@@ -1,6 +1,6 @@
 #' Run a external sql file
 #'
-#' @param sql_var vector of variables to use in sql file e.g. c("schema='dbName',xwalkprev='inFC')
+#' @param sql_var vector of variables to use in sql file e.g. c("schema='dbName',xwalkprev='inFC'), when set to NULL, runs sql_file without variable replacement
 #' @param sql_file path and file name of sql file
 #' @param pg_db pg database name
 #' @param host host of db e.g. 'localhost', defaults to NULL

--- a/R/run-sql-psql.R
+++ b/R/run-sql-psql.R
@@ -18,11 +18,17 @@ run_sql_psql <- function(sql_var, sql_file, pg_db, host=NULL){
   if (is.null(host)){
     host<-'localhost'
   }
+
   cmd <-  c("-d", pg_db, "-f", sql_file, "-h", host)
-  for(i in sql_var){
-    cmd <- append(cmd, "-v")
-    cmd <- append(cmd, i)
-  }
+  if (is.null(sql_var)){
+    print(cmd)
+    print(system2("psql", args = cmd, wait = TRUE, stdout = TRUE, stderr = TRUE))
+  } else {
+    for (i in sql_var){
+      cmd <- append(cmd, "-v")
+      cmd <- append(cmd, i)
+    }
   print(cmd)
   print(system2("psql", args = cmd, wait = TRUE, stdout = TRUE, stderr = TRUE))
+  }
 }

--- a/man/run_sql_psql.Rd
+++ b/man/run_sql_psql.Rd
@@ -7,7 +7,7 @@
 run_sql_psql(sql_var, sql_file, pg_db, host = NULL)
 }
 \arguments{
-\item{sql_var}{vector of variables to use in sql file e.g. c("schema='dbName',xwalkprev='inFC')}
+\item{sql_var}{vector of variables to use in sql file e.g. c("schema='dbName',xwalkprev='inFC'), when set to NULL, runs sql_file without variable replacement}
 
 \item{sql_file}{path and file name of sql file}
 


### PR DESCRIPTION
Added option for when one wants to run a command with no variables.
When user sets sql_var = NULL, sql_file is ran without variable substitution. 
Documentation updated.