### PR TITLE
Removing temp rasters generated by rasterize_terra & rasterize_gdal

### DIFF
--- a/R/create-mask-tif.R
+++ b/R/create-mask-tif.R
@@ -42,5 +42,6 @@ create_mask_tif <- function(
   rast_band[!is.na(rast_band)]  <- 1
 
   terra::writeRaster(rast_band, dest, datatype = datatype, overwrite = TRUE)
+  terra::tmpFiles(remove=TRUE)
   return(dest)
 }

--- a/R/import-to-pg-gr-skey.R
+++ b/R/import-to-pg-gr-skey.R
@@ -374,6 +374,9 @@ import_to_pg_gr_skey <- function(
             out_tif_name = glue("{dst_tbl}.tif"),
             datatype     = 'INT4U',
             nodata       = no_data_value)
+			
+		  print('Removing TEMP files created by TERRA')
+		  terra::tmpFiles(remove = TRUE)
 
           in_df <- dadmtools::tif_to_gr_skey_tbl(
             src_tif_filename = dst_ras_filename,

--- a/R/import-to-pg-gr-skey.R
+++ b/R/import-to-pg-gr-skey.R
@@ -375,7 +375,7 @@ import_to_pg_gr_skey <- function(
             datatype     = 'INT4U',
             nodata       = no_data_value)
 			
-		  print('Removing TEMP files created by TERRA')
+		  #--Removing TEMP raster files created by TERRA/gdal_rasterize
 		  terra::tmpFiles(remove = TRUE)
 
           in_df <- dadmtools::tif_to_gr_skey_tbl(
@@ -529,6 +529,9 @@ import_to_pg_gr_skey <- function(
             where         = where_clause_overlap
           )
 
+		  #--Removing TEMP raster files created by TERRA/gdal_rasterize
+		  terra::tmpFiles(remove = TRUE)
+		  
           in_df <- dadmtools::tif_to_gr_skey_tbl(
             src_tif_filename = dst_ras_filename,
             crop_extent      = crop_extent,

--- a/R/import-to-pg-gr-skey.R
+++ b/R/import-to-pg-gr-skey.R
@@ -557,13 +557,6 @@ import_to_pg_gr_skey <- function(
 
         print(glue('Created PG table: {grskey_schema}.{dst_gr_skey_tbl} from values in tif and gr_skey'))
 
-
-
-
-
-
-
-
       }
 
       if (src_type %in% c("shapefile", "shp")) {
@@ -685,6 +678,7 @@ if(!overlap_ind){
     overlap_ind = overlap_ind ,
     overlap_group_fields = overlap_group_fields
   )
-
+  #--Removing TEMP raster files created by TERRA/gdal_rasterize
+  terra::tmpFiles(remove = TRUE)
 }
 

--- a/R/rasterize-gdal.R
+++ b/R/rasterize-gdal.R
@@ -70,7 +70,7 @@ rasterize_gdal <- function(
   print(glue("Writing raster: {dst_ras_filename} using datatype: {datatype}"))
   print(paste('gdal_rasterize', datatype, comp, value, proj, extent_string, cell_size, src, dst_ras_filename, sql, nodata))
   print(system2('gdal_rasterize',args = c(datatype, comp, value, proj, extent_string, cell_size, src, dst_ras_filename, sql, nodata), stderr = TRUE))
-
+  terra::tmpFiles(remove=TRUE)
   print('Raster created successfully.')
   return(dst_ras_filename)
 

--- a/R/rasterize-terra.R
+++ b/R/rasterize-terra.R
@@ -25,7 +25,7 @@ rasterize_terra <- function(src_sf,
                           datatype ='INT4S',
                           nodata = 0)
 {
-
+  print('Welcome to the Jungle!')
   dest_tif <- file.path(out_tif_path, out_tif_name)
 
   # Check if the file exists

--- a/R/rasterize-terra.R
+++ b/R/rasterize-terra.R
@@ -25,7 +25,6 @@ rasterize_terra <- function(src_sf,
                           datatype ='INT4S',
                           nodata = 0)
 {
-  print('Welcome to the Jungle!')
   dest_tif <- file.path(out_tif_path, out_tif_name)
 
   # Check if the file exists
@@ -50,8 +49,6 @@ rasterize_terra <- function(src_sf,
     }
   print(glue("Writing raster: {dest_tif} using datatype: {datatype}"))
   terra::writeRaster(rast_band, dest_tif, datatype = datatype, overwrite = TRUE, NAflag = nodata)
-
-  print('Cleanup on aisle TERRA temp raster')
   terra::tmpFiles(remove=TRUE)
   print('Raster created successfully.')
   return(dest_tif)

--- a/R/rasterize-terra.R
+++ b/R/rasterize-terra.R
@@ -51,6 +51,7 @@ rasterize_terra <- function(src_sf,
   print(glue("Writing raster: {dest_tif} using datatype: {datatype}"))
   terra::writeRaster(rast_band, dest_tif, datatype = datatype, overwrite = TRUE, NAflag = nodata)
 
+  print('Cleanup on aisle TERRA temp raster')
   terra::tmpFiles(remove=TRUE)
   print('Raster created successfully.')
   return(dest_tif)


### PR DESCRIPTION
I added some calls to terra::tmpFiles(remove = TRUE) in rasterize_terra, rasterize_gdal and import_to_pg_gr_skey to resolve buildup of temp rasters during overlap processing